### PR TITLE
Fix for new download URLs after 2.1.0 release

### DIFF
--- a/pvm.sh
+++ b/pvm.sh
@@ -142,7 +142,14 @@ pvm()
 
 	    appname=play-${VERSION}
 	    zipfile="${appname}.zip"
-	    download_url="http://download.playframework.org/releases/${zipfile}"
+
+	    MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f 1)
+	    MINOR_VERSION=$(echo "$VERSION" | cut -d '.' -f 2)
+	    if [[ "$MAJOR_VERSION" == "1" || ("$MAJOR_VERSION" == "2" && "$MINOR_VERSION" == "0") ]]; then
+	        download_url="http://downloads.typesafe.com/releases/${zipfile}"
+	    else
+	        download_url="http://downloads.typesafe.com/play/${VERSION}/${zipfile}"
+	    fi
 
 	    http_code=$(curl -w '%{http_code}' -sIL "${download_url}" -o /dev/null)
 	    if (( $? != 0 )); then 


### PR DESCRIPTION
This commit should handle the new download URLs introduced with the release of 2.1.0, it should also remain compatible with old versions.

The download server has been changed from `download.playframework.org` to `downloads.typesafe.com`.

The path has changed from `/releases/play-X.X.X.zip` to `/play/X.X.X/play-X.X.X.zip` for versions 2.1.0 and up.
